### PR TITLE
Add simple Flask dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ performance chart.
 If a ticker's price history can't be retrieved (for example if yfinance has no
 data), the program prints a warning and skips that symbol. Skipped tickers are
 not written to the daily portfolio CSV and are ignored when calculating totals.
+
+## Dashboard
+
+Start the Flask dashboard to view the portfolio, trade log, and latest graph:
+
+```bash
+python dashboard/app.py
+```
+
+Visit `http://localhost:5000/` in your browser.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,50 @@
+from flask import Flask, send_file, render_template_string
+import pandas as pd
+from pathlib import Path
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CSV_DIR = BASE_DIR / "Scripts and CSV Files"
+GRAPH_DIR = BASE_DIR / "graphs"
+
+sys.path.append(str(CSV_DIR))
+from Generate_Graph import generate_graph
+
+app = Flask(__name__)
+
+@app.route("/")
+def show_portfolio():
+    file_path = CSV_DIR / "chatgpt_portfolio_update.csv"
+    if not file_path.exists():
+        return "Portfolio file not found", 404
+    df = pd.read_csv(file_path)
+    return render_template_string("""
+    <h1>Portfolio</h1>
+    {{table|safe}}
+    """, table=df.to_html(index=False))
+
+@app.route("/log")
+def show_log():
+    file_candidates = [BASE_DIR / "chatgpt_trade_log.csv", CSV_DIR / "chatgpt_trade_log.csv"]
+    file_path = next((p for p in file_candidates if p.exists()), None)
+    if not file_path:
+        return "Trade log not found", 404
+    df = pd.read_csv(file_path)
+    return render_template_string("""
+    <h1>Trade Log</h1>
+    {{table|safe}}
+    """, table=df.to_html(index=False))
+
+@app.route("/graph")
+def show_graph():
+    GRAPH_DIR.mkdir(exist_ok=True)
+    png_files = list(GRAPH_DIR.glob("*.png"))
+    if png_files:
+        latest = max(png_files, key=lambda p: p.stat().st_mtime)
+    else:
+        latest = GRAPH_DIR / "performance.png"
+        generate_graph(latest.as_posix(), show=False)
+    return send_file(latest, mimetype="image/png")
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ yfinance
 pytest
 numpy
 matplotlib
+Flask


### PR DESCRIPTION
## Summary
- add Flask web dashboard to browse portfolio CSV, trade log, and latest graph
- document how to run the dashboard
- require Flask dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e7d901608330b96f90aa41aff293