### PR TITLE
Add daily scheduler and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,27 @@ python dashboard/app.py
 ```
 
 Visit `http://localhost:5000/` in your browser.
+
+## Automating Daily Runs
+
+Use `daily_run.py` to schedule `Trading_Script.py` every day.
+
+```bash
+python daily_run.py --portfolio my_portfolio.csv --cash 100 --time 09:00
+```
+
+### Background execution
+
+Keep the scheduler running even after you close the terminal:
+
+```bash
+nohup python daily_run.py --portfolio my_portfolio.csv --cash 100 --time 09:00 &
+```
+
+### Cron example
+
+Add this to your crontab to start at boot:
+
+```
+@reboot /usr/bin/python /path/to/daily_run.py --portfolio /path/to/my_portfolio.csv --cash 100 --time 09:00 >> /path/to/trade.log 2>&1
+```

--- a/daily_run.py
+++ b/daily_run.py
@@ -1,0 +1,51 @@
+import argparse
+import subprocess
+import time
+from pathlib import Path
+
+import schedule
+
+
+def run_trading_script(portfolio: str, cash: float) -> None:
+    """Execute Trading_Script.py with the given arguments."""
+    script = Path(__file__).parent / "Scripts and CSV Files" / "Trading_Script.py"
+    subprocess.run(
+        ["python", str(script), "--portfolio", portfolio, "--cash", str(cash)],
+        check=True,
+    )
+
+
+def build_daily_scheduler(
+    portfolio: str, cash: float, run_time: str = "09:00"
+) -> schedule.Scheduler:
+    """Return a scheduler that runs the trading script every day."""
+    sched = schedule.Scheduler()
+    sched.every().day.at(run_time).do(run_trading_script, portfolio, cash)
+    return sched
+
+
+def run_scheduler(sched: schedule.Scheduler, *, once: bool = False) -> None:
+    """Run the scheduler either once or continuously."""
+    if once:
+        sched.run_all(delay_seconds=0)
+        return
+
+    while True:
+        sched.run_pending()
+        time.sleep(60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run daily trading script")
+    parser.add_argument("--portfolio", required=True, help="Portfolio CSV path")
+    parser.add_argument("--cash", required=True, type=float, help="Starting cash")
+    parser.add_argument("--time", default="09:00", help="HH:MM time for run")
+
+    args = parser.parse_args()
+
+    scheduler = build_daily_scheduler(args.portfolio, args.cash, args.time)
+    run_scheduler(scheduler)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy
 matplotlib
 aiohttp
 Flask
+
+schedule

--- a/tests/test_daily_run.py
+++ b/tests/test_daily_run.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import daily_run
+
+
+def test_run_scheduler_invokes_job(monkeypatch):
+    called = {}
+
+    def fake_run(portfolio, cash):
+        called['args'] = (portfolio, cash)
+
+    monkeypatch.setattr(daily_run, 'run_trading_script', fake_run)
+    sched = daily_run.build_daily_scheduler('pf.csv', 50.0, run_time='00:00')
+    daily_run.run_scheduler(sched, once=True)
+
+    assert called['args'] == ('pf.csv', 50.0)


### PR DESCRIPTION
## Summary
- add `daily_run.py` to schedule `Trading_Script.py`
- document running the scheduler in the README
- include `schedule` in requirements
- test scheduler behaviour with pytest

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ec30ca9c8330a89d725e4deb0d6e