### PR TITLE
Add broker API module with paper trading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
+Set up access to your brokerage API by exporting credentials before running the scripts:
+```bash
+export BROKER_API_KEY="<your-key>"
+export BROKER_SECRET_KEY="<your-secret>"
+# Optional: point to a different paper trading base URL
+export BROKER_BASE_URL="https://paper-api.alpaca.markets"
+```
+This project uses the paper trading API only, so no real money is automatically traded.
+
 
 # Follow Along
 The experiment runs June 2025 to December 2025.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 matplotlib
 aiohttp
 Flask
+requests

--- a/src/broker/__init__.py
+++ b/src/broker/__init__.py
@@ -1,0 +1,72 @@
+"""Simple broker API wrapper for paper trading.
+
+This module communicates with a remote brokerage API using
+credentials provided through environment variables. Only
+paper-trading endpoints are used.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import requests
+
+# Environment variable names
+_API_KEY_ENV = "BROKER_API_KEY"
+_SECRET_KEY_ENV = "BROKER_SECRET_KEY"
+_BASE_URL_ENV = "BROKER_BASE_URL"
+
+
+def _get_headers() -> Dict[str, str]:
+    """Return authentication headers for the brokerage API."""
+    api_key = os.getenv(_API_KEY_ENV)
+    secret_key = os.getenv(_SECRET_KEY_ENV)
+    if not api_key or not secret_key:
+        raise EnvironmentError(
+            f"{_API_KEY_ENV} and {_SECRET_KEY_ENV} must be set for broker access"
+        )
+    return {
+        "APCA-API-KEY-ID": api_key,
+        "APCA-API-SECRET-KEY": secret_key,
+        "Content-Type": "application/json",
+    }
+
+
+def _base_url() -> str:
+    """Return the base URL for the brokerage API."""
+    return os.getenv(_BASE_URL_ENV, "https://paper-api.alpaca.markets")
+
+
+def place_order(symbol: str, qty: int, side: str, order_type: str = "market", time_in_force: str = "gtc") -> Dict[str, Any]:
+    """Place an order through the brokerage API.
+
+    Parameters
+    ----------
+    symbol:
+        Stock ticker to trade.
+    qty:
+        Number of shares.
+    side:
+        "buy" or "sell".
+    order_type:
+        Order type, defaults to "market".
+    time_in_force:
+        How long the order remains active.
+
+    Returns
+    -------
+    Dict[str, Any]
+        JSON response from the API.
+    """
+    url = f"{_base_url()}/v2/orders"
+    payload = {
+        "symbol": symbol,
+        "qty": qty,
+        "side": side,
+        "type": order_type,
+        "time_in_force": time_in_force,
+    }
+    response = requests.post(url, json=payload, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/src/portfolio/__init__.py
+++ b/src/portfolio/__init__.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Any
 
 import pandas as pd
 import yfinance as yf
+from ..broker import place_order
 
 
 class Portfolio:
@@ -245,4 +246,12 @@ class Portfolio:
 
         cash = cash + shares_sold * sell_price
         return cash, chatgpt_portfolio
+
+    def paper_buy(self, ticker: str, qty: int, order_type: str = "market"):
+        """Place a paper buy order through the broker API."""
+        return place_order(ticker, qty, "buy", order_type)
+
+    def paper_sell(self, ticker: str, qty: int, order_type: str = "market"):
+        """Place a paper sell order through the broker API."""
+        return place_order(ticker, qty, "sell", order_type)
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,60 @@
+import pathlib
+import sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import os
+import json
+from unittest import mock
+
+import pytest
+
+from src.broker import place_order
+
+
+def test_place_order_makes_request(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, headers=None, timeout=10):
+        calls['url'] = url
+        calls['json'] = json
+        calls['headers'] = headers
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'status': 'accepted'}
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.post', fake_post)
+
+    result = place_order('AAA', 1, 'buy')
+
+    assert calls['url'] == 'http://example.com/v2/orders'
+    assert calls['json']['symbol'] == 'AAA'
+    assert calls['json']['qty'] == 1
+    assert calls['headers']['APCA-API-KEY-ID'] == 'key'
+    assert result['status'] == 'accepted'
+
+
+def test_portfolio_paper_buy_calls_broker(monkeypatch):
+    from src.portfolio import Portfolio
+
+    recorded = {}
+    def fake_place(ticker, qty, side, order_type='market', time_in_force='gtc'):
+        recorded['ticker'] = ticker
+        recorded['qty'] = qty
+        recorded['side'] = side
+        return {'ok': True}
+
+    monkeypatch.setattr('src.portfolio.place_order', fake_place)
+
+    p = Portfolio(today='2025-08-05')
+    result = p.paper_buy('BBB', 3)
+    assert recorded['ticker'] == 'BBB'
+    assert recorded['qty'] == 3
+    assert recorded['side'] == 'buy'
+    assert result['ok']
+


### PR DESCRIPTION
## Summary
- add new `broker` module for paper-trading API communication
- read API credentials from environment variables
- expose `paper_buy`/`paper_sell` helpers in `Portfolio`
- document broker API setup in README
- include tests for new broker module

## Testing
- `pip install --break-system-packages --no-deps -r requirements.txt`
- `pip install --break-system-packages curl_cffi`
- `pip install --break-system-packages beautifulsoup4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ec5abbac8330b048ddc1c9ad2c8c