### PR TITLE
Add tests for manual trade logging

### DIFF
--- a/tests/test_manual_buy.py
+++ b/tests/test_manual_buy.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import pytest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src import portfolio as portfolio_module
+from src.portfolio import Portfolio
+
+
+def test_log_manual_buy_creates_entry(tmp_path, monkeypatch):
+    portfolio_obj = Portfolio(today="2025-08-05")
+
+    # Dummy data instead of real network call
+    monkeypatch.setattr(portfolio_module.yf, "download", lambda *a, **k: pd.DataFrame({"Close": [10.0]}))
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "0")
+
+    work = tmp_path / "buy"
+    work.mkdir()
+    (work / "Scripts and CSV Files").mkdir()
+    monkeypatch.chdir(work)
+
+    cash, pf = portfolio_obj.log_manual_buy(
+        buy_price=10.0,
+        shares=5,
+        ticker="AAA",
+        cash=100.0,
+        stoploss=5.0,
+        chatgpt_portfolio=pd.DataFrame(),
+    )
+
+    df = pd.read_csv("Scripts and CSV Files/chatgpt_trade_log.csv")
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["Ticker"] == "AAA"
+    assert row["Buy Price"] == 10.0
+    assert row["Shares Bought"] == 5
+    assert cash == pytest.approx(50.0)
+    assert pf.iloc[0]["ticker"] == "AAA"
+    assert int(pf.iloc[0]["shares"]) == 5
+

--- a/tests/test_manual_sell.py
+++ b/tests/test_manual_sell.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.portfolio import Portfolio
+
+
+def test_log_manual_sell_updates_portfolio(tmp_path, monkeypatch):
+    portfolio_obj = Portfolio(today="2025-08-06")
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "profit")
+
+    work = tmp_path / "sell"
+    work.mkdir()
+    (work / "Scripts and CSV Files").mkdir()
+    monkeypatch.chdir(work)
+
+    portfolio = pd.DataFrame([
+        {"ticker": "AAA", "shares": 10, "stop_loss": 0.0, "buy_price": 2.0, "cost_basis": 20.0}
+    ])
+
+    cash, updated = portfolio_obj.log_manual_sell(3.0, 5, "AAA", 100.0, portfolio)
+
+    df = pd.read_csv("Scripts and CSV Files/chatgpt_trade_log.csv")
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["Ticker"] == "AAA"
+    assert row["Shares Sold"] == 5
+    assert cash == pytest.approx(115.0)
+    assert int(updated.iloc[0]["shares"]) == 5
+    assert updated.iloc[0]["cost_basis"] == pytest.approx(10.0)
+
+
+def test_log_manual_sell_too_many_shares(tmp_path, monkeypatch):
+    portfolio_obj = Portfolio(today="2025-08-07")
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "profit")
+
+    work = tmp_path / "fail"
+    work.mkdir()
+    (work / "Scripts and CSV Files").mkdir()
+    monkeypatch.chdir(work)
+
+    portfolio = pd.DataFrame([
+        {"ticker": "AAA", "shares": 4, "stop_loss": 0.0, "buy_price": 2.0, "cost_basis": 8.0}
+    ])
+
+    with pytest.raises(ValueError):
+        portfolio_obj.log_manual_sell(3.0, 5, "AAA", 100.0, portfolio)


### PR DESCRIPTION
## Summary
- add regression tests for `log_manual_buy` and `log_manual_sell`
- ensure tests patch network calls and cover error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a151816b08330a416224e8bca20fb