### PR TITLE
Improve dashboard with templates

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, send_file, render_template_string, url_for
+from flask import Flask, send_file, render_template, url_for
 import pandas as pd
 from pathlib import Path
 import sys
@@ -10,20 +10,9 @@ GRAPH_DIR = BASE_DIR / "graphs"
 sys.path.append(str(CSV_DIR))
 from Generate_Graph import generate_graph
 
-app = Flask(__name__)
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+app = Flask(__name__, template_folder=TEMPLATE_DIR)
 
-
-def render_page(content: str) -> str:
-    """Wrap content in a basic page with navigation links."""
-    nav = (
-        f'<nav>'
-        f'<a href="{url_for("show_portfolio")}">Portfolio</a> | '
-        f'<a href="{url_for("show_log")}">Trade Log</a> | '
-        f'<a href="{url_for("show_graph")}">Graph</a> | '
-        f'<a href="{url_for("show_summary")}">Summary</a>'
-        f'</nav><hr>'
-    )
-    return render_template_string("""{{nav|safe}}{{content|safe}}""", nav=nav, content=content)
 
 @app.route("/")
 def show_portfolio():
@@ -31,8 +20,8 @@ def show_portfolio():
     if not file_path.exists():
         return "Portfolio file not found", 404
     df = pd.read_csv(file_path)
-    content = f"<h1>Portfolio</h1>{df.to_html(index=False)}"
-    return render_page(content)
+    table = df.to_html(index=False, classes="table table-striped")
+    return render_template("portfolio.html", table=table)
 
 @app.route("/log")
 def show_log():
@@ -41,8 +30,8 @@ def show_log():
     if not file_path:
         return "Trade log not found", 404
     df = pd.read_csv(file_path)
-    content = f"<h1>Trade Log</h1>{df.to_html(index=False)}"
-    return render_page(content)
+    table = df.to_html(index=False, classes="table table-striped")
+    return render_template("log.html", table=table)
 
 @app.route("/graph_image")
 def graph_image():
@@ -58,8 +47,7 @@ def graph_image():
 
 @app.route("/graph")
 def show_graph():
-    img_tag = f'<img src="{url_for("graph_image")}" alt="Performance graph">'
-    return render_page(img_tag)
+    return render_template("graph.html")
 
 
 @app.route("/summary")
@@ -72,16 +60,35 @@ def show_summary():
     if totals.empty:
         return "No summary data", 404
     latest = totals.iloc[-1]
-    summary = f"""
-    <h1>Summary ({latest['Date']})</h1>
-    <ul>
-        <li>Total Value: {latest['Total Value']}</li>
-        <li>PnL: {latest['PnL']}</li>
-        <li>Cash Balance: {latest['Cash Balance']}</li>
-        <li>Total Equity: {latest['Total Equity']}</li>
-    </ul>
-    """
-    return render_page(summary)
+    return render_template(
+        "summary.html",
+        date=latest["Date"],
+        total=latest["Total Value"],
+        pnl=latest["PnL"],
+        cash=latest["Cash Balance"],
+        equity=latest["Total Equity"],
+    )
+
+
+@app.route("/overview")
+def overview():
+    """Display graph and summary together."""
+    file_path = CSV_DIR / "chatgpt_portfolio_update.csv"
+    if not file_path.exists():
+        return "Portfolio file not found", 404
+    df = pd.read_csv(file_path)
+    totals = df[df["Ticker"] == "TOTAL"]
+    if totals.empty:
+        return "No summary data", 404
+    latest = totals.iloc[-1]
+    return render_template(
+        "overview.html",
+        date=latest["Date"],
+        total=latest["Total Value"],
+        pnl=latest["PnL"],
+        cash=latest["Cash Balance"],
+        equity=latest["Total Equity"],
+    )
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title or "Dashboard" }}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { padding-top: 60px; }
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('show_portfolio') }}">Trading Dashboard</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('show_portfolio') }}">Portfolio</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('show_log') }}">Trade Log</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('show_graph') }}">Graph</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('show_summary') }}">Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('overview') }}">Overview</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+  {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/dashboard/templates/graph.html
+++ b/dashboard/templates/graph.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Performance Graph</h1>
+<img src="{{ url_for('graph_image') }}" alt="Performance graph" class="img-fluid">
+{% endblock %}

--- a/dashboard/templates/log.html
+++ b/dashboard/templates/log.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Trade Log</h1>
+{{ table | safe }}
+{% endblock %}

--- a/dashboard/templates/overview.html
+++ b/dashboard/templates/overview.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Dashboard Overview</h1>
+<div class="row">
+  <div class="col-md-6">
+    <img src="{{ url_for('graph_image') }}" alt="Performance graph" class="img-fluid">
+  </div>
+  <div class="col-md-6">
+    <h2>Account Summary ({{ date }})</h2>
+    <ul>
+      <li>Total Value: {{ total }}</li>
+      <li>PnL: {{ pnl }}</li>
+      <li>Cash Balance: {{ cash }}</li>
+      <li>Total Equity: {{ equity }}</li>
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/dashboard/templates/portfolio.html
+++ b/dashboard/templates/portfolio.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Portfolio</h1>
+{{ table | safe }}
+{% endblock %}

--- a/dashboard/templates/summary.html
+++ b/dashboard/templates/summary.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Summary ({{ date }})</h1>
+<ul>
+  <li>Total Value: {{ total }}</li>
+  <li>PnL: {{ pnl }}</li>
+  <li>Cash Balance: {{ cash }}</li>
+  <li>Total Equity: {{ equity }}</li>
+</ul>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -37,4 +37,6 @@ def test_dashboard_routes(tmp_path, monkeypatch):
         assert client.get("/log").status_code == 200
         assert client.get("/summary").status_code == 200
         assert client.get("/graph_image").status_code == 200
+        assert client.get("/overview").status_code == 200
+
 


### PR DESCRIPTION
## Summary
- redesign Flask dashboard with bootstrap templates
- add new `/overview` route combining the account summary with the graph
- ensure all existing routes use HTML templates
- cover new route in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a19d9fb6c8330913f5c90b1405abb