### PR TITLE
Add extended Alpaca API helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ BROKER_BASE_URL=https://paper-api.alpaca.markets
 ```
 Environment variables take precedence over values in the file. This project uses the paper trading API only, so no real money is automatically traded.
 
-The `src.broker` module now exposes helper functions to interact with the
+The `src.broker` module exposes helper functions to interact with the
 Alpaca paper API. Use `place_order` to submit trades, `get_account` to fetch
-account details and `list_positions` to inspect open positions.
+account details and `list_positions` to inspect open positions. Additional
+helpers let you manage orders (`list_orders`, `cancel_order`, `cancel_all_orders`),
+view tradable assets via `list_assets`, and close positions with
+`close_position` or `close_all_positions`.
 
 
 # Follow Along

--- a/src/broker/__init__.py
+++ b/src/broker/__init__.py
@@ -91,3 +91,75 @@ def list_positions() -> List[Dict[str, Any]]:
     response = requests.get(url, headers=_get_headers(), timeout=10)
     response.raise_for_status()
     return response.json()
+
+
+def list_assets(status: str | None = None, asset_class: str | None = None) -> List[Dict[str, Any]]:
+    """Return available assets from the brokerage API."""
+    url = f"{_base_url()}/v2/assets"
+    params = {}
+    if status:
+        params["status"] = status
+    if asset_class:
+        params["asset_class"] = asset_class
+    response = requests.get(url, headers=_get_headers(), params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_order(order_id: str) -> Dict[str, Any]:
+    """Return a specific order by its ID."""
+    url = f"{_base_url()}/v2/orders/{order_id}"
+    response = requests.get(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def list_orders(status: str = "open", limit: int | None = None) -> List[Dict[str, Any]]:
+    """Return a list of orders from the brokerage API."""
+    url = f"{_base_url()}/v2/orders"
+    params = {"status": status}
+    if limit is not None:
+        params["limit"] = limit
+    response = requests.get(url, headers=_get_headers(), params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def cancel_order(order_id: str) -> Dict[str, Any]:
+    """Cancel an open order."""
+    url = f"{_base_url()}/v2/orders/{order_id}"
+    response = requests.delete(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def cancel_all_orders() -> List[Dict[str, Any]]:
+    """Cancel all open orders."""
+    url = f"{_base_url()}/v2/orders"
+    response = requests.delete(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def close_position(symbol: str) -> Dict[str, Any]:
+    """Close an open position by symbol."""
+    url = f"{_base_url()}/v2/positions/{symbol}"
+    response = requests.delete(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def close_all_positions() -> List[Dict[str, Any]]:
+    """Close all open positions."""
+    url = f"{_base_url()}/v2/positions"
+    response = requests.delete(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_clock() -> Dict[str, Any]:
+    """Return the current market clock."""
+    url = f"{_base_url()}/v2/clock"
+    response = requests.get(url, headers=_get_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -132,3 +132,143 @@ def test_dotenv_loaded(monkeypatch):
     assert recorded['path'] == expected
     assert recorded['override'] is False
 
+
+def test_list_assets(monkeypatch):
+    calls = {}
+
+    def fake_get(url, headers=None, params=None, timeout=10):
+        calls['url'] = url
+        calls['params'] = params
+        calls['headers'] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [{'symbol': 'AAA'}]
+
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.get', fake_get)
+
+    result = broker.list_assets(status='active')
+
+    assert calls['url'] == 'http://example.com/v2/assets'
+    assert calls['params']['status'] == 'active'
+    assert result[0]['symbol'] == 'AAA'
+
+
+def test_get_order(monkeypatch):
+    calls = {}
+
+    def fake_get(url, headers=None, timeout=10):
+        calls['url'] = url
+        calls['headers'] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'id': '123'}
+
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.get', fake_get)
+
+    result = broker.get_order('123')
+
+    assert calls['url'] == 'http://example.com/v2/orders/123'
+    assert result['id'] == '123'
+
+
+def test_cancel_order(monkeypatch):
+    calls = {}
+
+    def fake_delete(url, headers=None, timeout=10):
+        calls['url'] = url
+        calls['headers'] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'status': 'canceled'}
+
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.delete', fake_delete)
+
+    result = broker.cancel_order('abc')
+
+    assert calls['url'] == 'http://example.com/v2/orders/abc'
+    assert result['status'] == 'canceled'
+
+
+def test_list_orders(monkeypatch):
+    calls = {}
+
+    def fake_get(url, headers=None, params=None, timeout=10):
+        calls['url'] = url
+        calls['params'] = params
+        calls['headers'] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [{'id': '1'}]
+
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.get', fake_get)
+
+    result = broker.list_orders(status='all', limit=5)
+
+    assert calls['url'] == 'http://example.com/v2/orders'
+    assert calls['params']['status'] == 'all'
+    assert calls['params']['limit'] == 5
+    assert result[0]['id'] == '1'
+
+
+def test_close_position(monkeypatch):
+    calls = {}
+
+    def fake_delete(url, headers=None, timeout=10):
+        calls['url'] = url
+        calls['headers'] = headers
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'status': 'closed'}
+
+        return Resp()
+
+    monkeypatch.setenv('BROKER_API_KEY', 'key')
+    monkeypatch.setenv('BROKER_SECRET_KEY', 'secret')
+    monkeypatch.setenv('BROKER_BASE_URL', 'http://example.com')
+    monkeypatch.setattr('src.broker.requests.delete', fake_delete)
+
+    result = broker.close_position('ZZZ')
+
+    assert calls['url'] == 'http://example.com/v2/positions/ZZZ'
+    assert result['status'] == 'closed'
+


### PR DESCRIPTION
## Summary
- extend `src.broker` with functions for assets, orders and positions
- document broker utilities in README
- test new broker functions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a239c09748330b6cbc2d5e0274cb9