### PR TITLE
Add bot status tracking and dashboard route

### DIFF
--- a/Scripts and CSV Files/Trading_Script.py
+++ b/Scripts and CSV Files/Trading_Script.py
@@ -8,6 +8,14 @@ import sys
 import json
 import yaml
 
+STATUS_FILE = Path("bot_status.json")
+
+def _write_status(action: str) -> None:
+    """Write the last action message to ``bot_status.json``."""
+    data = {"last_action": action, "time": datetime.utcnow().isoformat()}
+    with STATUS_FILE.open("w") as f:
+        json.dump(data, f)
+
 from src.portfolio import Portfolio
 
 sys.path.append("Scripts and CSV Files")
@@ -118,6 +126,7 @@ def main():
     graphs_dir.mkdir(exist_ok=True)
     graph_file = graphs_dir / f"performance_{today}.png"
     generate_graph(graph_file.as_posix(), show=False)
+    _write_status("trading script executed")
 
 
 if __name__ == "__main__":

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,11 +1,14 @@
-from flask import Flask, send_file, render_template, url_for
+from flask import Flask, send_file, render_template, url_for, jsonify, request
 import pandas as pd
 from pathlib import Path
 import sys
 
+from src import bot_status
+
 BASE_DIR = Path(__file__).resolve().parents[1]
 CSV_DIR = BASE_DIR / "Scripts and CSV Files"
 GRAPH_DIR = BASE_DIR / "graphs"
+BOT_STATUS_FILE = BASE_DIR / "bot_status.json"
 
 sys.path.append(str(CSV_DIR))
 from Generate_Graph import generate_graph
@@ -89,6 +92,15 @@ def overview():
         cash=latest["Cash Balance"],
         equity=latest["Total Equity"],
     )
+
+
+@app.route("/status")
+def show_status():
+    """Display live account status."""
+    status = bot_status.get_status(BOT_STATUS_FILE)
+    if request.args.get("json"):
+        return jsonify(status)
+    return render_template("status.html", status=status)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/dashboard/templates/status.html
+++ b/dashboard/templates/status.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Bot Status</h1>
+<p>Last action: <span id="last-action">{{ status.last_action or '' }}</span></p>
+<p>Equity: $<span id="equity">{{ status.equity }}</span></p>
+<h3>Positions</h3>
+<table class="table table-striped">
+  <thead><tr><th>Symbol</th><th>Qty</th><th>Market Value</th></tr></thead>
+  <tbody id="positions-body">
+  {% for p in status.positions %}
+    <tr><td>{{ p['symbol'] }}</td><td>{{ p['qty'] }}</td><td>{{ p['market_value'] }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h3>Open Orders</h3>
+<table class="table table-striped">
+  <thead><tr><th>ID</th><th>Symbol</th><th>Qty</th><th>Side</th></tr></thead>
+  <tbody id="orders-body">
+  {% for o in status.orders %}
+    <tr><td>{{ o['id'] }}</td><td>{{ o['symbol'] }}</td><td>{{ o['qty'] }}</td><td>{{ o['side'] }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<script>
+async function refresh(){
+  const res = await fetch('{{ url_for('show_status') }}?json=1');
+  if(!res.ok) return;
+  const data = await res.json();
+  document.getElementById('last-action').textContent = data.last_action || '';
+  document.getElementById('equity').textContent = data.equity;
+  const posBody = document.getElementById('positions-body');
+  posBody.innerHTML = '';
+  for (const p of data.positions){
+    posBody.insertAdjacentHTML('beforeend', `<tr><td>${p.symbol||p.symbol}</td><td>${p.qty}</td><td>${p.market_value}</td></tr>`);
+  }
+  const ordBody = document.getElementById('orders-body');
+  ordBody.innerHTML = '';
+  for (const o of data.orders){
+    ordBody.insertAdjacentHTML('beforeend', `<tr><td>${o.id}</td><td>${o.symbol}</td><td>${o.qty}</td><td>${o.side}</td></tr>`);
+  }
+}
+setInterval(refresh, 5000);
+</script>
+{% endblock %}

--- a/src/bot_status.py
+++ b/src/bot_status.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from . import broker
+
+# Default location for the status json file relative to repo root
+STATUS_FILE = Path(__file__).resolve().parents[1] / "bot_status.json"
+
+
+def _read_last_action(file: Path = STATUS_FILE) -> str | None:
+    """Return the last recorded action from ``file`` if present."""
+    if file.exists():
+        try:
+            with file.open() as f:
+                data = json.load(f)
+            return data.get("last_action")
+        except Exception:
+            return None
+    return None
+
+
+def get_status(status_file: Path = STATUS_FILE) -> Dict[str, Any]:
+    """Return latest account status information.
+
+    Parameters
+    ----------
+    status_file:
+        Path to the json file storing the last action note.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with keys ``timestamp``, ``equity``, ``positions``,
+        ``orders`` and ``last_action``.
+    """
+    account = broker.get_account()
+    equity = account.get("equity")
+    positions = broker.list_positions()
+    orders = broker.list_orders(status="open")
+
+    return {
+        "timestamp": datetime.utcnow().isoformat(),
+        "equity": equity,
+        "positions": positions,
+        "orders": orders,
+        "last_action": _read_last_action(status_file),
+    }

--- a/tests/test_bot_status.py
+++ b/tests/test_bot_status.py
@@ -1,0 +1,22 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import src.bot_status as bot_status
+
+
+def test_get_status(monkeypatch, tmp_path):
+    monkeypatch.setattr(bot_status, "STATUS_FILE", tmp_path / "status.json")
+    monkeypatch.setattr(bot_status.broker, "get_account", lambda: {"equity": "50"})
+    monkeypatch.setattr(bot_status.broker, "list_positions", lambda: [{"symbol": "AAA"}])
+    monkeypatch.setattr(bot_status.broker, "list_orders", lambda status="open": [{"id": "1"}])
+    tmp = bot_status.STATUS_FILE
+    # create last action file
+    (tmp).write_text('{"last_action": "did"}')
+
+    result = bot_status.get_status(bot_status.STATUS_FILE)
+    assert result["equity"] == "50"
+    assert result["positions"][0]["symbol"] == "AAA"
+    assert result["orders"][0]["id"] == "1"
+    assert result["last_action"] == "did"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,3 +40,27 @@ def test_dashboard_routes(tmp_path, monkeypatch):
         assert client.get("/overview").status_code == 200
 
 
+def test_status_route(tmp_path, monkeypatch):
+    csv_dir, graph_dir = _setup_files(tmp_path)
+    monkeypatch.setattr(app_module, "CSV_DIR", csv_dir)
+    monkeypatch.setattr(app_module, "GRAPH_DIR", graph_dir)
+    monkeypatch.setattr(app_module, "BOT_STATUS_FILE", tmp_path / "bot_status.json")
+
+    def fake_status(file=None):
+        return {
+            "timestamp": "now",
+            "equity": 100,
+            "positions": [],
+            "orders": [],
+            "last_action": "test",
+        }
+
+    monkeypatch.setattr(app_module.bot_status, "get_status", fake_status)
+
+    with app.test_client() as client:
+        assert client.get("/status").status_code == 200
+        resp = client.get("/status?json=1")
+        assert resp.is_json
+        assert resp.get_json()["equity"] == 100
+
+


### PR DESCRIPTION
## Summary
- record last trading action for the dashboard
- expose a `/status` route in the dashboard with auto-refresh
- implement `bot_status` helper module
- show status page template in the dashboard
- add tests for the new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a26831a2483308a265e3c40882b31