### PR TITLE
Handle missing schedule module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ ChatGPT 4o for decision-making
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+# If you see errors about missing packages such as `schedule`, make sure this
+# step completed successfully.
 ```
 Set up access to your brokerage API by either exporting credentials or creating a `.env` file.
 A sample `.env` is provided and automatically loaded when the `src.broker` module is imported:

--- a/daily_run.py
+++ b/daily_run.py
@@ -3,7 +3,13 @@ import time
 
 from src import trading
 
-import schedule
+try:
+    import schedule
+except ImportError as exc:  # pragma: no cover - runtime import guard
+    raise ImportError(
+        "Missing optional dependency 'schedule'.\n"
+        "Install it with 'pip install schedule' or 'pip install -r requirements.txt'."
+    ) from exc
 
 
 def run_trading_script(portfolio: str, cash: float) -> None:


### PR DESCRIPTION
## Summary
- guard `schedule` import in `daily_run.py` and show helpful message when missing
- add note in README about ensuring `pip install -r requirements.txt` runs successfully

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2b4b905c83308f110aaee9220e3e