### PR TITLE
Add automatic startup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Please Reach out here: nathanbsmith.business@gmail.com
 
 ## Example Usage
 
+Running `python main.py` with no arguments will automatically launch the
+dashboard and a daily trading scheduler using the defaults from `config.yaml`.
+
 Run the trading script with your portfolio CSV and starting cash:
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -6,11 +6,31 @@ import argparse
 from src import trading
 from dashboard.app import app as dashboard_app
 import daily_run
+import threading
+
+
+DEFAULT_PORTFOLIO = "Scripts and CSV Files/chatgpt_portfolio_update.csv"
+DEFAULT_CONFIG = "config.yaml"
+DEFAULT_RUN_TIME = "09:00"
+
+
+def start_all() -> None:
+    """Run scheduler and dashboard using default settings."""
+    config = trading.load_config(DEFAULT_CONFIG)
+    cash = config.get("default_cash", 0.0)
+
+    sched = daily_run.build_daily_scheduler(
+        DEFAULT_PORTFOLIO, cash, run_time=DEFAULT_RUN_TIME
+    )
+    thread = threading.Thread(target=daily_run.run_scheduler, args=(sched,), daemon=True)
+    thread.start()
+
+    dashboard_app.run(host="127.0.0.1", port=5000)
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Project command line interface")
-    sub = parser.add_subparsers(dest="command", required=True)
+    sub = parser.add_subparsers(dest="command")
 
     dash_p = sub.add_parser("dashboard", help="Run the dashboard server")
     dash_p.add_argument("--host", default="127.0.0.1")
@@ -28,7 +48,9 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
-    if args.command == "dashboard":
+    if args.command is None:
+        start_all()
+    elif args.command == "dashboard":
         dashboard_app.run(host=args.host, port=args.port)
     elif args.command == "trade":
         trading.run(args.portfolio, args.cash, args.config)


### PR DESCRIPTION
## Summary
- allow `main.py` to run all modules with default settings
- document default startup in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2e9ebf5483308366447f033759bf