### PR TITLE
Update main entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,40 +1,30 @@
-"""Command line entry point for project utilities."""
+"""Project entry point that launches all core modules."""
 from __future__ import annotations
 
-import argparse
+from threading import Thread
 
 from src import trading
 from dashboard.app import app as dashboard_app
 import daily_run
 
 
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Project command line interface")
-    sub = parser.add_subparsers(dest="command", required=True)
+DEFAULT_PORTFOLIO = "Scripts and CSV Files/chatgpt_portfolio_update.csv"
 
-    dash_p = sub.add_parser("dashboard", help="Run the dashboard server")
-    dash_p.add_argument("--host", default="127.0.0.1")
-    dash_p.add_argument("--port", type=int, default=5000)
 
-    trade_p = sub.add_parser("trade", help="Run trading script once")
-    trade_p.add_argument("--portfolio", required=True)
-    trade_p.add_argument("--cash", type=float)
-    trade_p.add_argument("--config", default="config.yaml")
+def _start_scheduler() -> None:
+    """Run the daily scheduler in a background thread."""
+    sched = daily_run.build_daily_scheduler(DEFAULT_PORTFOLIO, cash=0.0)
+    daily_run.run_scheduler(sched)
 
-    sched_p = sub.add_parser("schedule", help="Run daily scheduler")
-    sched_p.add_argument("--portfolio", required=True)
-    sched_p.add_argument("--cash", required=True, type=float)
-    sched_p.add_argument("--time", default="09:00")
 
-    args = parser.parse_args(argv)
+def main() -> None:
+    """Launch trading, scheduler and dashboard without CLI args."""
+    trading.run(DEFAULT_PORTFOLIO, None, "config.yaml")
 
-    if args.command == "dashboard":
-        dashboard_app.run(host=args.host, port=args.port)
-    elif args.command == "trade":
-        trading.run(args.portfolio, args.cash, args.config)
-    elif args.command == "schedule":
-        sched = daily_run.build_daily_scheduler(args.portfolio, args.cash, args.time)
-        daily_run.run_scheduler(sched)
+    # Start scheduler in a daemon thread so the dashboard can continue serving
+    Thread(target=_start_scheduler, daemon=True).start()
+
+    dashboard_app.run(host="127.0.0.1", port=5000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify main launcher
- automatically run the trading script, scheduler, and dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2e9ebf5483308366447f033759bf