### PR TITLE
Fix default portfolio CSV column handling

### DIFF
--- a/src/portfolio/__init__.py
+++ b/src/portfolio/__init__.py
@@ -31,6 +31,18 @@ class Portfolio:
         if isinstance(portfolio, str):
             portfolio = pd.read_csv(portfolio)
 
+        # Normalize column names if they come from a daily update CSV
+        rename_map = {
+            "Ticker": "ticker",
+            "Shares": "shares",
+            "Stop Loss": "stop_loss",
+            "Buy Price": "buy_price",
+            "Cost Basis": "cost_basis",
+        }
+        for old, new in rename_map.items():
+            if old in portfolio.columns and new not in portfolio.columns:
+                portfolio = portfolio.rename(columns={old: new})
+
         tickers = portfolio["ticker"].tolist()
         price_map = asyncio.run(self._download_all(tickers))
 

--- a/src/trading.py
+++ b/src/trading.py
@@ -83,6 +83,17 @@ def run(portfolio_path: str, cash: float | None, config_path: str, *, today: str
     default_stop = config.get("default_stop_loss")
 
     portfolio_df = pd.read_csv(portfolio_path)
+    # Normalize common column names to match the expected lowercase format
+    rename_map = {
+        "Ticker": "ticker",
+        "Shares": "shares",
+        "Stop Loss": "stop_loss",
+        "Buy Price": "buy_price",
+        "Cost Basis": "cost_basis",
+    }
+    for old, new in rename_map.items():
+        if old in portfolio_df.columns and new not in portfolio_df.columns:
+            portfolio_df = portfolio_df.rename(columns={old: new})
     if default_stop is not None:
         if "stop_loss" not in portfolio_df.columns:
             portfolio_df["stop_loss"] = default_stop


### PR DESCRIPTION
## Summary
- handle different column names when loading portfolio CSVs
- normalize portfolio columns inside `Portfolio.process`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a30566ff0833084e29cc56b649559