### PR TITLE
Add portfolio editor to dashboard

### DIFF
--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -14,6 +14,7 @@
     <a class="font-semibold mr-6" href="{{ url_for('show_portfolio') }}">Trading Dashboard</a>
     <div class="space-x-4">
       <a class="hover:underline" href="{{ url_for('show_portfolio') }}">Portfolio</a>
+      <a class="hover:underline" href="{{ url_for('edit_portfolio') }}">Edit Portfolio</a>
       <a class="hover:underline" href="{{ url_for('show_log') }}">Trade Log</a>
       <a class="hover:underline" href="{{ url_for('show_graph') }}">Graph</a>
       <a class="hover:underline" href="{{ url_for('show_summary') }}">Summary</a>

--- a/dashboard/templates/portfolio_edit.html
+++ b/dashboard/templates/portfolio_edit.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Edit Portfolio CSV</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  <div>
+    <label class="block">Upload CSV</label>
+    <input type="file" name="file" class="border">
+  </div>
+  <div>
+    <label class="block">Edit CSV Data</label>
+    <textarea name="csv_text" rows="10" class="border w-full font-mono">{{ csv_text }}</textarea>
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Save</button>
+</form>
+<hr class="my-4">
+{{ table | safe }}
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -107,3 +107,21 @@ def test_config_route_get_post(tmp_path, monkeypatch):
     assert env_vals["BROKER_BASE_URL"] == "http://example.com"
 
 
+def test_portfolio_edit(tmp_path, monkeypatch):
+    csv_dir, graph_dir = _setup_files(tmp_path)
+    monkeypatch.setattr(app_module, "CSV_DIR", csv_dir)
+
+    with app.test_client() as client:
+        resp = client.get("/portfolio/edit")
+        assert resp.status_code == 200
+
+        new_csv = "Date,Ticker,Total Value\n2025-08-11,TOTAL,150\n"
+        resp = client.post("/portfolio/edit", data={"csv_text": new_csv})
+        assert resp.status_code == 200
+
+    saved = csv_dir / "chatgpt_portfolio_update.csv"
+    assert "150" in saved.read_text()
+    backups = list((csv_dir / "backups").glob("chatgpt_portfolio_update_*.csv"))
+    assert len(backups) == 1
+
+


### PR DESCRIPTION
## Summary
- allow editing portfolio CSV from `/portfolio/edit`
- link to the new editor in the navigation bar
- back up the existing CSV before saving edits
- add unit tests for the new route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a34a2d3348330aeef6b4898ce324d