### PR TITLE
Add manual trade handling to dashboard

### DIFF
--- a/dashboard/templates/manual_buy.html
+++ b/dashboard/templates/manual_buy.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Manual Buy</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Ticker</label>
+    <input type="text" name="ticker" class="border px-2 py-1" required>
+  </div>
+  <div>
+    <label class="block">Shares</label>
+    <input type="number" name="shares" class="border px-2 py-1" required>
+  </div>
+  <div>
+    <label class="block">Price</label>
+    <input type="text" name="price" class="border px-2 py-1" required>
+  </div>
+  <div>
+    <label class="block">Stop Loss</label>
+    <input type="text" name="stop_loss" class="border px-2 py-1" required>
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Submit</button>
+</form>
+{% endblock %}

--- a/dashboard/templates/manual_sell.html
+++ b/dashboard/templates/manual_sell.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Manual Sell</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Ticker</label>
+    <input type="text" name="ticker" class="border px-2 py-1" required>
+  </div>
+  <div>
+    <label class="block">Shares</label>
+    <input type="number" name="shares" class="border px-2 py-1" required>
+  </div>
+  <div>
+    <label class="block">Price</label>
+    <input type="text" name="price" class="border px-2 py-1" required>
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `/manual_buy` and `/manual_sell` routes
- refresh portfolio data after logging trades
- add templates for manual trade forms

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a34aa277483308246e462aaf86f78