### PR TITLE
Fix Flask route duplication

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -419,28 +419,6 @@ def show_audit():
                     continue
     return render_template("audit.html", entries=log_entries)
 
-@app.route("/portfolio/edit", methods=["POST"])
-@login_required
-def edit_portfolio():
-    return "Not implemented", 501
-
-
-@app.route("/manual_buy", methods=["POST"])
-@login_required
-def manual_buy():
-    return "Not implemented", 501
-
-
-@app.route("/manual_sell", methods=["POST"])
-@login_required
-def manual_sell():
-    return "Not implemented", 501
-
-
-@app.route("/scheduler", methods=["POST"])
-@login_required
-def scheduler():
-    return "Not implemented", 501
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -147,7 +147,7 @@ def test_config_route_get_post(tmp_path, monkeypatch):
 
 
 def test_scheduler_route(tmp_path, monkeypatch):
-    csv_dir, graph_dir = _setup_files(tmp_path)
+    csv_dir, graph_dir, audit_file = _setup_files(tmp_path)
     cfg_file = tmp_path / "config.yaml"
     cfg_file.write_text("")
 
@@ -173,7 +173,7 @@ def test_scheduler_route(tmp_path, monkeypatch):
     assert started["time"] == "10:30"
 
 def test_portfolio_edit(tmp_path, monkeypatch):
-    csv_dir, graph_dir = _setup_files(tmp_path)
+    csv_dir, graph_dir, audit_file = _setup_files(tmp_path)
     monkeypatch.setattr(app_module, "CSV_DIR", csv_dir)
 
     with app.test_client() as client:


### PR DESCRIPTION
## Summary
- remove duplicate route definitions in `dashboard/app.py`
- fix tests to expect audit log path from `_setup_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a39a474c48330b25ff1bd7915986d