### PR TITLE
Fix processing of portfolio rows with missing data

### DIFF
--- a/src/portfolio/__init__.py
+++ b/src/portfolio/__init__.py
@@ -44,6 +44,11 @@ class Portfolio:
             if old in portfolio.columns and new not in portfolio.columns:
                 portfolio = portfolio.rename(columns={old: new})
 
+        # Drop any summary rows or incomplete entries that may appear in the CSV
+        if "ticker" in portfolio.columns:
+            portfolio = portfolio[~portfolio["ticker"].astype(str).str.upper().eq("TOTAL")]
+        portfolio = portfolio.dropna(subset=["shares", "buy_price", "stop_loss"], how="any")
+
         tickers = portfolio["ticker"].tolist()
         price_map = asyncio.run(self._download_all(tickers))
 

--- a/src/trading.py
+++ b/src/trading.py
@@ -95,6 +95,12 @@ def run(portfolio_path: str, cash: float | None, config_path: str, *, today: str
         if old in portfolio_df.columns and new not in portfolio_df.columns:
             portfolio_df = portfolio_df.rename(columns={old: new})
 
+    # Remove summary rows like "TOTAL" and any rows missing share counts
+    if "ticker" in portfolio_df.columns:
+        portfolio_df = portfolio_df[~portfolio_df["ticker"].str.upper().eq("TOTAL")]
+    if "shares" in portfolio_df.columns:
+        portfolio_df = portfolio_df[portfolio_df["shares"].notna()]
+
     # Derive missing buy price from cost basis and shares
     if "buy_price" not in portfolio_df.columns and {
         "cost_basis",
@@ -108,7 +114,7 @@ def run(portfolio_path: str, cash: float | None, config_path: str, *, today: str
         if "stop_loss" not in portfolio_df.columns:
             portfolio_df["stop_loss"] = default_stop
         else:
-            portfolio_df["stop_loss"].fillna(default_stop, inplace=True)
+            portfolio_df["stop_loss"] = portfolio_df["stop_loss"].fillna(default_stop)
 
     portfolio = Portfolio(today=today)
     portfolio.process(portfolio_df, cash)


### PR DESCRIPTION
## Summary
- skip portfolio summary rows before processing
- drop missing rows in Portfolio.process
- avoid FutureWarning when filling stop loss

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b80d6d468833098ce2b9cf06f02a4